### PR TITLE
Format codeblocks with prettier

### DIFF
--- a/API.md
+++ b/API.md
@@ -307,7 +307,7 @@ The `flatten` operator creates a new Emitter that will:
   )
   ```
 
-- If the `args` passed into `flatten` contains a function, that will be invoked on the value received before it's flattened into the Emitter. This means instead of having a `map` followed by a `flatten`, you can combine them i.e. "flatmap".
+* If the `args` passed into `flatten` contains a function, that will be invoked on the value received before it's flattened into the Emitter. This means instead of having a `map` followed by a `flatten`, you can combine them i.e. "flatmap".
 
   ```js
   // returns ['H10', 'H20', 'H30', 'I10', 'I20', 'I30']
@@ -609,10 +609,10 @@ await waitFor(() => document.body.querySelector('div'))
 The `on(obj, name)` helper will create a new Emitter that listens on the named channel `name` of the specified object `obj`. If `obj` is an EventTarget or EventEmitter it will create a listener that nexts the events on the Emitter, that also gets cleaned when the Emitter resolves or rejects.
 
 ```js
-;(clicks = on(document.body, 'click')),
-  clicks.each(() => {
-    console.log('clicked')
-  })
+clicks = on(document.body, 'click'))
+clicks.each(() => {
+  console.log('clicked')
+})
 clicks.resolve()
 ```
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -4,7 +4,7 @@
 
 The composition model is very similar to and inspired by transducers' approach of creating composable algorithmic transformations that can work across different contexts.
 
-The main difference revolves around the higher-order aspect. This was actually where earlier experiments started. However, this turns out to be too slow. In addition, whilst the reducing signature is quite powerful, the limited model does break down quickly. 
+The main difference revolves around the higher-order aspect. This was actually where earlier experiments started. However, this turns out to be too slow. In addition, whilst the reducing signature is quite powerful, the limited model does break down quickly.
 
 To understand the difference in code terms, instead of using a reducing function like this:
 
@@ -24,7 +24,7 @@ Rather it's more like `{ send }`, as we also have a way to make other things acc
 
 The concept of serialising new output collections from the stream of values using `into` also exists in the ["default reducers"](/API.md#reduce) API.
 
-### How does this relate to Iterators/Generators? 
+### How does this relate to Iterators/Generators?
 
 This was demonstrated above, you can use iteration to step through an Emitter where applicable, e.g:
 
@@ -35,7 +35,7 @@ for (const v of map(d => d + 1, [1,2,3]))
 [...map(d => d + 1, [1,2,3])]
 ```
 
-An additional point to highlight is that iterators are objects that look like `{ next, return, throw }`. Emitters look like `{ next, resolve, reject }`. Due to the similiarity, it may seem reasonable to think about enhancing the existing object. This was explored and decided against. It would conflate things in a confusing way e.g. Emitter has a `done` property, and vends `value`, iterator has no `done` property and vends `{ done, value }` tuples. Accordingly, it's a trivial thin wrapping to go from one to the other (see below), and best to consistently align with the Promise-terminology instead (e.g. `resolve` vs `return`). 
+An additional point to highlight is that iterators are objects that look like `{ next, return, throw }`. Emitters look like `{ next, resolve, reject }`. Due to the similiarity, it may seem reasonable to think about enhancing the existing object. This was explored and decided against. It would conflate things in a confusing way e.g. Emitter has a `done` property, and vends `value`, iterator has no `done` property and vends `{ done, value }` tuples. Accordingly, it's a trivial thin wrapping to go from one to the other (see below), and best to consistently align with the Promise-terminology instead (e.g. `resolve` vs `return`).
 
 ```js
 [Symbol.iterator](){
@@ -49,7 +49,7 @@ An additional point to highlight is that iterators are objects that look like `{
 
 ### How does this relate to `ReadableStream`/`WritableStream`?
 
-There are some similarities, particularly in the API e.g. the way the controller is exposed to functions passed in the constructor. However, these are very specialised for [particular I/O use cases and unsuitable for more general cases](https://github.com/whatwg/streams/blob/master/FAQ.md). As a part of the Emitter design, there are specificially no proliferation of base Emitters like readable/transform/writable Emitters (or other [fragmentations like sources/sinks/pullables/pullers/listenables/listeners](https://github.com/staltz/callbag-basics#terminology)) - only one type to minimise cognitive overhead. They are point-to-point, whereas Emitter handles multiple consumers. They are pull-based, whereas Emitter is push-based. Emitter does have a backpressure mechanism, but it's not as intricate as the options these streams provide (e.g. custom queuing strategy). The `buffer` operator is probably closer, in that nexting a value onto a buffer node, does not immediately send it but queues it up to a watermark. Hence the closest analogy would be Emitter with in-built buffering. It may be possible to further subclass it to provide similar API, but those specific use cases are probably better served by separate primitives. 
+There are some similarities, particularly in the API e.g. the way the controller is exposed to functions passed in the constructor. However, these are very specialised for [particular I/O use cases and unsuitable for more general cases](https://github.com/whatwg/streams/blob/master/FAQ.md). As a part of the Emitter design, there are specificially no proliferation of base Emitters like readable/transform/writable Emitters (or other [fragmentations like sources/sinks/pullables/pullers/listenables/listeners](https://github.com/staltz/callbag-basics#terminology)) - only one type to minimise cognitive overhead. They are point-to-point, whereas Emitter handles multiple consumers. They are pull-based, whereas Emitter is push-based. Emitter does have a backpressure mechanism, but it's not as intricate as the options these streams provide (e.g. custom queuing strategy). The `buffer` operator is probably closer, in that nexting a value onto a buffer node, does not immediately send it but queues it up to a watermark. Hence the closest analogy would be Emitter with in-built buffering. It may be possible to further subclass it to provide similar API, but those specific use cases are probably better served by separate primitives.
 
 Since these, as well as existing Node streams, implement `Symbol.asyncIterator`, they interoperate pretty fine already. That is, you could pull from a readable stream, compose them with the operators, or reduce into a writable stream.
 
@@ -63,12 +63,12 @@ run([1,2,3], map(..), reduce(fs.createWriteStream('file.txt')))
 * Observables are similarly push-based primitives
 * Observables do not handle multiple consumers (by design)
 * Observables invent new error-handling semantics ("complete/error/done"), which becomes a barrier/challenge in integrating it with the rest of the language
-* Observables can be thought of as a higher level abstration than Emitter, one that internally generates a new Emitter on every subscription. 
-* Emitter would be closer to what is called a Subject in Observable-land. However, this is also not quite accurate as when you `next` onto an Emitter it's not just directly broadcasting to it's children, but rather lets the Emitter process the value. 
-* Emitter is _unidirectional_, all signals go downwards (whether that's values, or an Emitter resolving/rejecting like a Promise would). A child can never affect a parent by design, especially not implicitly. This gives developers guarantees which make them easier to reason about. Observables, and other libraries, are built on a _bidirectional_ architecture. When a subscription is made, a signal shoots upwards, and then values start coming back down. This in part contributes to making them harder to understand/implement. It seems this design is also a by-product of the original method-chaining API: when you have `A.op().op().subscribe()` you're subscribing on the last node, which means a signal has to travel back up somehow. However, with more modern forms of the API using `pipe` or the pipeline operator, as well as the API here, you are explicitly running A into B top-down, rather than from B to A. `compose` also returns something that represents the entire group, not just the last node in the chain, making it unnecessary for signals to travel up as well as down. 
+* Observables can be thought of as a higher level abstration than Emitter, one that internally generates a new Emitter on every subscription.
+* Emitter would be closer to what is called a Subject in Observable-land. However, this is also not quite accurate as when you `next` onto an Emitter it's not just directly broadcasting to it's children, but rather lets the Emitter process the value.
+* Emitter is _unidirectional_, all signals go downwards (whether that's values, or an Emitter resolving/rejecting like a Promise would). A child can never affect a parent by design, especially not implicitly. This gives developers guarantees which make them easier to reason about. Observables, and other libraries, are built on a _bidirectional_ architecture. When a subscription is made, a signal shoots upwards, and then values start coming back down. This in part contributes to making them harder to understand/implement. It seems this design is also a by-product of the original method-chaining API: when you have `A.op().op().subscribe()` you're subscribing on the last node, which means a signal has to travel back up somehow. However, with more modern forms of the API using `pipe` or the pipeline operator, as well as the API here, you are explicitly running A into B top-down, rather than from B to A. `compose` also returns something that represents the entire group, not just the last node in the chain, making it unnecessary for signals to travel up as well as down.
 
   One use-case that does perhaps become less ergonomic is `until` not automatically tearing down an Emitter somewhere higher up in the chain. However, this seems like a worthy trade-off as it manifests as the constraint of having to be explicit with what you are tearing down by having the condition first (a composed emitter is a single thing, hence tears down .
-  
+
   ```js
   // these will both return an array of three, however the first will not stop the array emitter
   run([...], map(), map(), until(3), reduce([]))
@@ -79,7 +79,7 @@ run([1,2,3], map(..), reduce(fs.createWriteStream('file.txt')))
 
 This would be a great candidate to expose via the new standard library, although it does not necessarily need to be blocked by that either. It could also neatly be a new global from which you can destructure the operators from i.e. `const { map, filter, run } = Emitter`.
 
-One example that gets mentioned a lot in the standard library proposal is [the generics](https://github.com/tc39/proposal-javascript-standard-library/blob/master/slides/JSL-TC39-July-2018.pdf)). The purpose of that proposal is about developing the infrastructure rather than the contents of the library, whereas this is a deeper design for that particular space inside it. However, it might be useful to highlight a few differences with the examples in those slides and explain why, so people develop the right expectations and mental model. 
+One example that gets mentioned a lot in the standard library proposal is [the generics](https://github.com/tc39/proposal-javascript-standard-library/blob/master/slides/JSL-TC39-July-2018.pdf)). The purpose of that proposal is about developing the infrastructure rather than the contents of the library, whereas this is a deeper design for that particular space inside it. However, it might be useful to highlight a few differences with the examples in those slides and explain why, so people develop the right expectations and mental model.
 
 * `map(predicate, arr)` rather than `map(arr, predicate)` means we can use `map(predicate)` and `map(predicate)(arr)`.
 * Operators like `map` do _not_ serialise any new representation, they only operate on a value. Otherwise we'd end up with a lot of unnecessary intermediate representations, less composable operators and much slower performance. `reduce` is the usual way to create a new representation. Hence if you wanted to transform a new array it would be closer to `reduce([], map(fn, arr))`. If that's a common enough use case, another form can be added that combines them, i.e. `map([], fn, arr)`.
@@ -88,7 +88,7 @@ One example that gets mentioned a lot in the standard library proposal is [the g
 ### Should this be done in X instead?
 
 * **Cross-platform Foundation:** This is a candidate for the runtime as it provides a platform-independent base that means any future abstraction built on top will be more portable across environments (e.g. browsers/node). In addition, once this lands, we then have a consistent and interoperable foundation for other parts of the standard library to build upon (e.g. stats libraries would heavily benefit from just writing operators, whilst having the mechanics of being lazy, composable, etc abstracted out).
-* **Standard Library:** The goal of the standard library proposal is specifically to move common functionality from userland into the runtime. These common operators for which people use libraries like lodash, Rx, etc and covered here are the main candidates. 
-* **Performance**: There are also [long term and performance concerns](https://github.com/whatwg/dom/issues/544#issuecomment-352499976) if this gets specified outside of TC39. 
-* **Syntax:** The current design is ergonomic to use, but the committee could also think about dedicated syntax in the longer term, for things like running, chaining, or evaluating an Emitter. 
+* **Standard Library:** The goal of the standard library proposal is specifically to move common functionality from userland into the runtime. These common operators for which people use libraries like lodash, Rx, etc and covered here are the main candidates.
+* **Performance**: There are also [long term and performance concerns](https://github.com/whatwg/dom/issues/544#issuecomment-352499976) if this gets specified outside of TC39.
+* **Syntax:** The current design is ergonomic to use, but the committee could also think about dedicated syntax in the longer term, for things like running, chaining, or evaluating an Emitter.
 * **Future Work:** Extensions to this proposal like signal-based programming which would allow reactive programming with sync-like code would certainly benefit from dedicated syntax.

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -1,6 +1,6 @@
 # Performance
 
-One of the goals and constraints of this proposal has been to achieve all the other design goals, whilst also matching or beating the high record set by most.js - which is not just a little bit faster, but an order of magnitude or two faster than alternatives. 
+One of the goals and constraints of this proposal has been to achieve all the other design goals, whilst also matching or beating the high record set by most.js - which is not just a little bit faster, but an order of magnitude or two faster than alternatives.
 
 Using the benchmark used by existing libraries in this space, Emitter comfortably and consistently outperforms most.js:
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 * Composable algorithmic transformations, decoupled from their input and outputs
 * Well-integrated with language rather than inventing lots of new concepts, (i.e. Promises, iteration, async iteration, etc)
 * Backwards-compatible unification of platform API (interfaces like EventTarget and EventEmitter)
-* [Ultra-High Performance (faster than most.js)](/PERFORMANCE.md) and memory efficient 
+* [Ultra-High Performance (faster than most.js)](/PERFORMANCE.md) and memory efficient
 
-<br> 
+<br>
 
 ## Reactive programming examples
 
@@ -17,10 +17,10 @@ Log XY coordinates of click events on `<button>` elements:
 const { on, map, filter, run } = Emitter
 
 run(
-  on(document, 'click')
-, filter(ev => ev.target.tagName === 'BUTTON')
-, map(ev => ({ x: ev.clientX, y: ev.clientY }))
-, coords => console.log(coords)
+  on(document, 'click'),
+  filter(ev => ev.target.tagName === 'BUTTON'),
+  map(ev => ({ x: ev.clientX, y: ev.clientY })),
+  coords => console.log(coords)
 )
 ```
 
@@ -29,10 +29,12 @@ Map clicks from two buttons to a stream of +1 and -1, merge them and render the 
 ```js
 const { on, map, tap, reduce, flatten, render } = Emitter
 
-const inc = map(() => 1, on(buttonA, 'click')) 
+const inc = map(() => 1, on(buttonA, 'click'))
 const dec = map(() => -1, on(buttonB, 'click'))
 const counter = reduce(0, flatten(inc, dec))
-const render = tap(total => { output.innerText = String(total) }, counter)
+const render = tap(total => {
+  output.innerText = String(total)
+}, counter)
 run(render)
 ```
 
@@ -43,14 +45,14 @@ const { run, until, once, flatten, reduce } = Emitter
 const { fork } = require('child_process')
 
 const processes = await run(
-  10
-, map(() => fork('peer.js'))
-, map(async peer => {
+  10,
+  map(() => fork('peer.js')),
+  map(async peer => {
     await until(d => d == 'connected', on(peer, 'message'))
     return peer
-  })
-, flatten()
-, reduce([])
+  }),
+  flatten(),
+  reduce([])
 )
 ```
 
@@ -59,23 +61,17 @@ const processes = await run(
 From a range of numbers, divide them by 4, remove any greater than 12, then start collecting those one by one:
 
 ```js
-function* range(from, to) { 
-  for (let i = from; i <= to; i++) yield i  
+function* range(from, to) {
+  for (let i = from; i <= to; i++) yield i
 }
 
-const arr = run(
-  range(40, 60)
-, map(d => d / 4)
-, filter(d => d < 12)
-, reduce([])
-)
+const arr = run(range(40, 60), map(d => d / 4), filter(d => d < 12), reduce([]))
 ```
 
 Transform a series of numbers one by one and log the result:
 
 ```js
-for (const d of map(d => d + 1, [1, 2, 3]))
-  console.log('transformed output', d)
+for (const d of map(d => d + 1, [1, 2, 3])) console.log('transformed output', d)
 ```
 
 Log whenever the user presses CTRL+C
@@ -91,25 +87,25 @@ for await (const d of filter(([n]) => n == 3, process.stdin))
 
 ### Transformation
 
-  * [`map`](/API.md#map)
-  * [`reduce`](/API.md#reduce)
-  * [`flatten`](/API.md#flatten)
+* [`map`](/API.md#map)
+* [`reduce`](/API.md#reduce)
+* [`flatten`](/API.md#flatten)
 
 ### Filtering
 
-  * [`filter`](/API.md#filter)
-  * [`until`](/API.md#until)
+* [`filter`](/API.md#filter)
+* [`until`](/API.md#until)
 
 ### Running
 
-  * [`run`](/API.md#run)
+* [`run`](/API.md#run)
 
 ### Creating
 
-  * [`on`](/API.md#on)
-  * [`once`](/API.md#once)
-  * [`from`](/API.md#from)
-  * [`compose`](/API.md#compose)
+* [`on`](/API.md#on)
+* [`once`](/API.md#once)
+* [`from`](/API.md#from)
+* [`compose`](/API.md#compose)
 
 <br>
 
@@ -120,15 +116,21 @@ For general background into this space, especially from more of a language persp
 For comparison, here would be Rob Pike's original example of [reducing tail latency using replicated search servers](https://talks.golang.org/2012/concurrency.slide#50) discussed in the talk:
 
 ```js
-const { race, timeout, until, reduce, flatten } = Emitter 
+const { race, timeout, until, reduce, flatten } = Emitter
 
 const results = await race(
-  timeout(80)
-, until(3, reduce([], flatten(
-    race(web1(query), web2(query))
-  , race(img1(query), img2(query))
-  , race(vid1(query), vid2(query))
-  )))
+  timeout(80),
+  until(
+    3,
+    reduce(
+      [],
+      flatten(
+        race(web1(query), web2(query)),
+        race(img1(query), img2(query)),
+        race(vid1(query), vid2(query))
+      )
+    )
+  )
 )
 ```
 

--- a/WALKTHROUGH.md
+++ b/WALKTHROUGH.md
@@ -2,7 +2,7 @@
 
 > **Composability arises from the regularity of shapes**
 
-This section aims to build up deeper intuition and familiarity step-by-step. The details here do _not_ represent common usage, or what users will be conscious of when using it regularly - composing, running, and evaluating Emitters will all become quickly intuitive after just playing with a few examples. This section is more useful for implementors to understand how the full processing model is built from a very small core. In addition, not everything here is intended to ship as a single proposal, but rather just document the cross-cutting concerns. 
+This section aims to build up deeper intuition and familiarity step-by-step. The details here do _not_ represent common usage, or what users will be conscious of when using it regularly - composing, running, and evaluating Emitters will all become quickly intuitive after just playing with a few examples. This section is more useful for implementors to understand how the full processing model is built from a very small core. In addition, not everything here is intended to ship as a single proposal, but rather just document the cross-cutting concerns.
 
 ### Multiple Values
 
@@ -19,12 +19,12 @@ With `Emitter`, you can send multiple values down a chain like this:
 
 ```js
 new Emitter(..)
-  .each(..) 
-  .each(..) 
-  .each(..) 
+  .each(..)
+  .each(..)
+  .each(..)
 ```
 
-### Error-handling 
+### Error-handling
 
 Because an Emitter extends a Promise, we inherit the same familiar error-handling mechanisms rather than inventing new ones i.e. it can be resolved, representing it's final value, or rejected, and finally can be used for any cleanup.
 
@@ -48,19 +48,23 @@ emitter.each(d => console.log('d', d)) // d 42
 emitter.next(42)
 ```
 
-However, in some cases it might be a little hacky to let anybody who gets hold of the emitter to send values to it's children from the outside. 
+However, in some cases it might be a little hacky to let anybody who gets hold of the emitter to send values to it's children from the outside.
 
 That's why Emitter lets the author control the behaviour, by giving access to the ability to send values via the revealing constructor pattern.
 
 ```js
 // only send true if an odd number was received
-new Emitter((d, i, { send }) => { if (d % 2) send(true) })
+new Emitter((d, i, { send }) => {
+  if (d % 2) send(true)
+})
 
 // delay sending the value by 1 second
-new Emitter((d, i, { send }) => { setTimeout(() => send(d), 1000) })
+new Emitter((d, i, { send }) => {
+  setTimeout(() => send(d), 1000)
+})
 
 // send 3 values, then resolve the emitter
-new Emitter((d, i, { send, resolve, reject }) => { 
+new Emitter((d, i, { send, resolve, reject }) => {
   send(1)
   send(2)
   send(3)
@@ -78,13 +82,13 @@ Note on the signature: This reflects the familiar pattern in JavaScript used by 
 
 `.each` connects one Emitter to another, and returns the last one.
 
-When you do: 
+When you do:
 
 ```js
 emitter.each(d => console.log('d', d))
 ```
 
-This is actually equivalent to: 
+This is actually equivalent to:
 
 ```js
 emitter.each(new Emitter(d => console.log('d', d)))
@@ -102,9 +106,7 @@ You can implement the usual `map`/`filter` suspects using higher-order functions
 const map = fn => (d, i, n) => n.send(fn(d))
 const filter = fn => (d, i, n) => fn(d) && n.send(d)
 
-emitter
-  .each(map(add1))
-  .each(filter(even))
+emitter.each(map(add1)).each(filter(even))
 ```
 
 Note that `.each` is also variadic, so the above would also be equivalent to:
@@ -113,7 +115,7 @@ Note that `.each` is also variadic, so the above would also be equivalent to:
 emitter.each(map(add1), filter(even))
 ```
 
-Implementation note: the actual `map` and `filter` operators are not implemented using higher-order functions, since capturing the predicate function that way would crash performance. Rather, they each create a new Emitter and take the predicate in the constructor: 
+Implementation note: the actual `map` and `filter` operators are not implemented using higher-order functions, since capturing the predicate function that way would crash performance. Rather, they each create a new Emitter and take the predicate in the constructor:
 
 ```js
 Emitter.map = fn => new MapEmitter(fn)
@@ -127,13 +129,13 @@ Passing a function configures the `next` behaviour - what happens when the Emitt
 new Emitter({ next, finally, resolve, reject, value, run })
 ```
 
-We'll come back to the `value` slot and `run` later. 
+We'll come back to the `value` slot and `run` later.
 
 These hooks can be installed via the constructor, but also via the class itself e.g:
 
 ```js
 class UDPMulticaster extends Emitter {
-  static finally(){ 
+  static finally() {
     return new Promise(resolve => this[socket].close(resolve))
   }
 }
@@ -156,7 +158,7 @@ from([1,2,3])
 
 ### Lazily Running
 
-`.each` just connects Emitters, it does not trigger any behaviour. You can use `.run()` to "run" an Emitter, which just means it calls the internal `run` hook (by default, a noop). You can also use the form `.run(...args)` to more easily connect a chain of Emitters and then run the source in one go i.e.: 
+`.each` just connects Emitters, it does not trigger any behaviour. You can use `.run()` to "run" an Emitter, which just means it calls the internal `run` hook (by default, a noop). You can also use the form `.run(...args)` to more easily connect a chain of Emitters and then run the source in one go i.e.:
 
 ```js
 A.each(B, C, D)
@@ -169,12 +171,12 @@ The expression `from([1, 2, 3])` creates an Emitter, that _when run_, will send 
 
 ```js
 new Emitter({
-  run(me){
+  run(me) {
     me.send(1)
     me.send(2)
     me.send(3)
     me.resolve()
-  }  
+  }
 })
 ```
 
@@ -202,7 +204,7 @@ run(
 
 ### Composition
 
-You can compose any set of Emitters into another Emitter and use it anywhere else you'd expect to use an Emitter. 
+You can compose any set of Emitters into another Emitter and use it anywhere else you'd expect to use an Emitter.
 
 ```js
 const transform = compose(
@@ -220,37 +222,46 @@ It's safe to never have to think about the `ComposedEmitter` as something other 
 
 ### Short-hand Composition
 
-The following would create a `ComposedEmitter` grouping an `ArrayEmitter` and a `MapEmitter`:  
+The following would create a `ComposedEmitter` grouping an `ArrayEmitter` and a `MapEmitter`:
 
 ```js
-compose([1,2,3], map(d => d + 1))
+compose(
+  [1, 2, 3],
+  map(d => d + 1)
+)
 ```
 
-However, all of the operators take their trailing arguments and compose them i.e.: 
+However, all of the operators take their trailing arguments and compose them i.e.:
 
 ```js
-Emitter.map = (fn, ...args) => compose(...args, new MapEmitter(fn))
+Emitter.map = (fn, ...args) =>
+  compose(
+    ...args,
+    new MapEmitter(fn)
+  )
 ```
- 
-Which means you could write things like: 
+
+Which means you could write things like:
 
 ```js
-map(d => d + 1, [1,2,3])
+map(d => d + 1, [1, 2, 3])
 ```
 
 This also naturally works recursively, which gives rise to the ability to write:
 
 ```js
-reduce(0, filter(even, map(add1, [1,2,3])))
+reduce(0, filter(even, map(add1, [1, 2, 3])))
 ```
 
 Or things like ([from the modern refactor of most.js](https://github.com/mostjs/core/blob/master/examples/counter/src/index.js)):
 
 ```js
-const inc = map(() => 1, buttonA) 
+const inc = map(() => 1, buttonA)
 const dec = map(() => -1, buttonB)
 const counter = reduce((acc, d) => acc + d, 0, flatten(inc, dec))
-const render = tap(total => { output.innerText = String(total) }, counter)
+const render = tap(total => {
+  output.innerText = String(total)
+}, counter)
 run(render)
 ```
 
@@ -259,8 +270,7 @@ run(render)
 How does this relate with the iteration protocol? You can think of `.run()` as one way to run an Emitter. The iteration protocol is another way to turn an Emitter, "one-by-one", by just calling `.next()` till it's done. This means you can do things like this:
 
 ```js
-for (const v of map(d => d + 1, [1,2,3]))
-  console.log(v)
+for (const v of map(d => d + 1, [1, 2, 3])) console.log(v)
 ```
 
 ### Named Channels
@@ -271,7 +281,7 @@ Emitter allows creating an Emitter on a named channel using `.on()`:
 emitter.on('click')
 ```
 
-This is similar to platform API that accepts a string and function. By omitting the second callback parameter, it returns an Emitter. This provides a unifying mental model with existing callback code and makes it easier to transition/upgrade, as the following are equivalent: 
+This is similar to platform API that accepts a string and function. By omitting the second callback parameter, it returns an Emitter. This provides a unifying mental model with existing callback code and makes it easier to transition/upgrade, as the following are equivalent:
 
 ```js
 emitter.on('click', fun)
@@ -288,7 +298,7 @@ emitter.on('click', filter(..), fun)
 
 ### Backward-Compatibility
 
-Instead of having to change existing interfaces at all, an even better approach is to use the static `Emitter.on` helper: 
+Instead of having to change existing interfaces at all, an even better approach is to use the static `Emitter.on` helper:
 
 ```js
 on(element, 'click').each(...args)
@@ -298,7 +308,7 @@ on(fork('./child'), 'message').each(...args)
 on(fork('./child'), 'message', ...args)
 ```
 
-Since the channels are linked using Symbols (could also be WeakMap), it means we don't pollute the public interface of objects with methods like `.on`, `.emit`, etc. 
+Since the channels are linked using Symbols (could also be WeakMap), it means we don't pollute the public interface of objects with methods like `.on`, `.emit`, etc.
 
 You can create a named channel with any arbitrary object. If an EventTarget or EventEmitter is used, it calls `addListener`/`addEventListener` when created and `removeListener`/`removeEventListener` when resolved/rejected.
 
@@ -314,12 +324,13 @@ Since `each`/`run` chains Emitters and returns the last one, and Emitter extends
 ```js
 // arr == [3]
 const arr = await run(
-  [1,2,3]
-, map(d => d + 1)
-, filter(d => d % 2)
-, reduce([])
+  [1, 2, 3],
+  map(d => d + 1),
+  filter(d => d % 2),
+  reduce([])
 )
 ```
+
 ```js
 await until(status => status == ‘connected’, on(peer, 'status'))
 ```
@@ -338,12 +349,7 @@ Using `await` in the previous `map`/`filter`/`reduce` with an array is redundant
 
 ```js
 // arr == [3]
-const arr = val(
-  [1,2,3]
-, map(d => d + 1)
-, filter(d => d % 2)
-, reduce([])
-)
+const arr = val([1, 2, 3], map(d => d + 1), filter(d => d % 2), reduce([]))
 ```
 
 This means we have a higher power-to-weight ratio single library of operators that covers synchronous and asynchronous use cases.
@@ -352,12 +358,12 @@ This means we have a higher power-to-weight ratio single library of operators th
 
 What is the return value of `.next(d)`? Rather, what would be _useful_ or _meaningful_ for its return value to be?
 
-The return value actually composes the return values of the children for that item. 
+The return value actually composes the return values of the children for that item.
 
 ```js
 emitter.each(() => 1)
 emitter.each(() => 2)
-emitter.next(42) // returns [1,2] 
+emitter.next(42) // returns [1,2]
 ```
 
 This works recursively too, plus where operators chain their send calls, we can successfully elide intermediate arrays to always have a flat list of the return values from the leaf nodes:
@@ -380,32 +386,40 @@ await Promise.all(emitter.next(3)) // wait till both have processed 3
 
 ### Concurrency Control
 
-Previously we showed `.run()` as one way to run an Emitter, as well as the iteration protocol to step through an Emitter until it's exhausted. `.run()` however does not care about the return values of the Emitter. Hence we have `run.limit(N)` which leverages that information, and will run an Emitter with a max of `N` inflight values. 
+Previously we showed `.run()` as one way to run an Emitter, as well as the iteration protocol to step through an Emitter until it's exhausted. `.run()` however does not care about the return values of the Emitter. Hence we have `run.limit(N)` which leverages that information, and will run an Emitter with a max of `N` inflight values.
 
 For example, let's say we have a framework that composes a pipeline that will search a predefined port space for a free server and then create an agent from that server:
 
 ```js
-const vendAgents = () => compose(
-  range(8000, 9000)
-, (port, i, { send }) => new Promise(resolve => createServer()
-    .on('error', () => resolve()) // EADDRINUSE, port in use, move on..
-    .listen(port, function(){ send(this), resolve() }) // created server
+const vendAgents = () =>
+  compose(
+    range(8000, 9000),
+    (port, i, { send }) =>
+      new Promise(
+        resolve =>
+          createServer()
+            .on('error', () => resolve()) // EADDRINUSE, port in use, move on..
+            .listen(port, function() {
+              send(this), resolve()
+            }) // created server
+      ),
+    map(createAgentFromServer)
   )
-, map(createAgentFromServer)
-)
 ```
 
 Then let's say a consumer wants to pull 3 new agents, concurrently trying upto 2 ports at a time:
 
 ```js
-const [agent1, agent2, agent3] = await run.limit(2)(reduce([], until(3, vendAgents())))
+const [agent1, agent2, agent3] = await run.limit(2)(
+  reduce([], until(3, vendAgents()))
+)
 ```
 
 If we didn't use `run.limit`, we'd overshoot and eagerly create too many servers. Notably, other consumers are also able to obtain however many new agents they want, at whatever rate they like (e.g. give me 5 new agents, trying up to 3 ports at a time).
 
-`run.await` is an alias for `run.limit(1)`, meaning await the results before moving on to the next value. This is conceptually the same as the iteration and async iteration protocol, but in a functional form. 
+`run.await` is an alias for `run.limit(1)`, meaning await the results before moving on to the next value. This is conceptually the same as the iteration and async iteration protocol, but in a functional form.
 
-For example, let's say we have some test cases that we want to step through one-by-one - in each case we create a new environment, test the scenario, tear down, before moving on to the next: 
+For example, let's say we have some test cases that we want to step through one-by-one - in each case we create a new environment, test the scenario, tear down, before moving on to the next:
 
 ```js
 await run.await({
@@ -419,7 +433,7 @@ await run.await({
 })
 ```
 
-`run.all` is an alias for `run.limit(Infinity)`, meaning you don't care when all the values have finished or in what order, but you just want to know when they are all done. 
+`run.all` is an alias for `run.limit(Infinity)`, meaning you don't care when all the values have finished or in what order, but you just want to know when they are all done.
 
 For example, let's say we have a cluster of peers. We want to teardown the entire cluster as fast possible, destroy all the peers in any order, but just await till they've all been destroyed:
 


### PR DESCRIPTION
Command: `prettier *.md --write --no-semi --single-quote`

Options chosen to reduce the amount of changes. Also prettier changes `-` to `*` for unordered lists which I have reverted to keep the diff small.

Diff is cleaner when ignoring whitespace: https://github.com/pemrouz/proposal-emitter/pull/15/files?w=1